### PR TITLE
UNO-392 BREAKING CHANGE: require a major update of `tao`

### DIFF
--- a/helper/StateWidget.php
+++ b/helper/StateWidget.php
@@ -18,25 +18,23 @@
  */
 namespace oat\taoResourceWorkflow\helper;
 
+use common_Utils;
+use core_kernel_classes_Resource;
 use oat\tao\helpers\form\elements\xhtml\XhtmlRenderingTrait;
 use oat\oatbox\service\ServiceManager;
 use oat\generis\model\OntologyAwareTrait;
 use oat\taoResourceWorkflow\model\ResourceWorkflowService;
+use tao_helpers_form_FormElement;
 
 /**
  * Widget to represent the current state
  */
-class StateWidget extends \tao_helpers_form_FormElement
+class StateWidget extends tao_helpers_form_FormElement
 {
     use XhtmlRenderingTrait;
     use OntologyAwareTrait;
 
-    /**
-     * A reference to the Widget Definition URI.
-     *
-     * @var string
-     */
-    protected $widget = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#StateWidget';
+    public const WIDGET_ID = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#StateWidget';
 
     /**
      * Render the Widget of the state and transition
@@ -49,9 +47,9 @@ class StateWidget extends \tao_helpers_form_FormElement
     {
         $val = $this->getValue();
         $stateResource = null;
-        if ($val instanceof \core_kernel_classes_Resource) {
+        if ($val instanceof core_kernel_classes_Resource) {
             $stateResource = $this->getValue();
-        } else if ($val !== null && \common_Utils::isUri($val)) {
+        } else if ($val !== null && common_Utils::isUri($val)) {
             $stateResource =  $this->getResource($val);
         }
         $returnValue = '';
@@ -81,7 +79,7 @@ class StateWidget extends \tao_helpers_form_FormElement
                                   $('.tree').trigger('refresh.taotree');
                                 } else {
                                   // error handling
-                                };
+                                }
                             }
                         });
                      });

--- a/manifest.php
+++ b/manifest.php
@@ -28,10 +28,10 @@ return array(
     'label' => 'Resource Workflow',
     'description' => 'Simple, resource/document based workflow allowing the transition between states',
     'license' => 'GPL-2.0',
-    'version' => '1.4.0',
+    'version' => '2.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
-        'tao' => '>=12.21.4',
+        'tao' => '>=45.0.0',
         'generis' => '>=5.9.0'
     ),
     'acl' => array(
@@ -53,7 +53,7 @@ return array(
     ),
     'constants' => array(
         # views directory
-        "DIR_VIEWS" => dirname(__FILE__).DIRECTORY_SEPARATOR."views".DIRECTORY_SEPARATOR,
+        "DIR_VIEWS" => __DIR__ .DIRECTORY_SEPARATOR."views".DIRECTORY_SEPARATOR,
 
         #BASE URL (usually the domain root)
         'BASE_URL' => ROOT_URL.'taoResourceWorkflow/',


### PR DESCRIPTION
- [UNO-392](https://oat-sa.atlassian.net/browse/UNO-392) BREAKING CHANGE: require a major update of `tao`
- [UNO-392](https://oat-sa.atlassian.net/browse/UNO-392) chore: use `WIDGET_ID` constant instead of a deprecated `$widget` property to define `StateWidget`'s widget URI

⚠️ Depends on `tao-core` [#2609](https://github.com/oat-sa/tao-core/pull/2609).