### PR TITLE
fix: show requests errors in modal window

### DIFF
--- a/helper/StateWidget.php
+++ b/helper/StateWidget.php
@@ -77,7 +77,7 @@ class StateWidget extends tao_helpers_form_FormElement
 
                 $returnValue .= '>' . _dh($transition->getLabel()) . '</a>';
                 $returnValue .= "<script type=\"text/javascript\">
-                    require(['jquery'], function($){
+                    require(['jquery', 'ui/feedback'], function($, feedback){
                         $(\"#" . $id . "\").on('click',function(event) {
                         event.preventDefault();
                         $.ajax({
@@ -88,8 +88,8 @@ class StateWidget extends tao_helpers_form_FormElement
                             success: function(response){
                                 if(response.success) {
                                   $('.tree').trigger('refresh.taotree');
-                                } else {
-                                  // error handling
+                                } else if (response.error && typeof response.error === 'string') {
+                                  feedback().error(response.error);
                                 }
                             }
                         });


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/ADF-1557

## What's Changed
- The possible error getting between steps now appears in the modal window

## How to test
1. Create a user with Item Author role
2. Assign this user to existing item with READ permission in Access Permissions on Items tab
3. Log in as Item Author user created on 1-2 steps
4. Choose the item from Preconditions on Items tab
5. Click ‘Submit item for review" or ‘Abandon item'
6. The error message: "You do not have the required rights to edit this resource." should be visible
7. Test it for different users using different locales for them, the notification message should be translated

Available for test on: http://test-viktar.playground.kitchen.it.taocloud.org:41531/tao/Main/login